### PR TITLE
Fix Supabase configuration for Google auth

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,9 +27,9 @@ app.secret_key = os.environ.get("SESSION_SECRET", "dev-secret-key-change-in-prod
 app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
 CORS(app)
 
-# ---------- Supabase (REST, not for SQLAlchemy) ----------
-app.config["SUPABASE_REST_URL"] = os.environ.get(
-    "SUPABASE_REST_URL",
+# ---------- Supabase configuration (used by frontend and auth blueprint) ----------
+app.config["SUPABASE_URL"] = os.environ.get(
+    "SUPABASE_URL",
     "https://okblwnznvxrrubgmrkig.supabase.co",
 )
 app.config["SUPABASE_ANON_KEY"] = os.environ.get(


### PR DESCRIPTION
## Summary
- Configure app to expose `SUPABASE_URL` and `SUPABASE_ANON_KEY`
- Build Supabase client from Flask config in auth blueprint

## Testing
- `python -m py_compile app.py auth.py`


------
https://chatgpt.com/codex/tasks/task_e_68979cae6be48324b6bfeb58ba621824