### PR TITLE
Add ability to delete tip entries

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -175,6 +175,39 @@
                 </div>
             </div>
 
+            <!-- Tip History -->
+            <div class="row mb-4">
+                <div class="col-12">
+                    <div class="card">
+                        <div class="card-header">
+                            <h5 class="card-title mb-0">Tip History</h5>
+                        </div>
+                        <div class="card-body">
+                            <div class="table-responsive">
+                                <table class="table table-striped">
+                                    <thead>
+                                        <tr>
+                                            <th>Date</th>
+                                            <th>Cash</th>
+                                            <th>Card</th>
+                                            <th>Total</th>
+                                            <th>Hours</th>
+                                            <th>Tips/Hour</th>
+                                            <th></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="tipsTableBody">
+                                        <tr>
+                                            <td colspan="7" class="text-center text-muted">Loading...</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- Dashboard Charts -->
             <div class="row mb-4">
                 <!-- Daily Trends -->


### PR DESCRIPTION
## Summary
- allow users to delete their own tip entries via new `/api/tips/<id>` DELETE endpoint
- display tip history table with delete buttons
- refresh dashboard after removals

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b249cf648324a3a5f5e63b465fa3