### PR TITLE
Add comments support for tip entries

### DIFF
--- a/api.py
+++ b/api.py
@@ -41,11 +41,19 @@ def validate_tip_entry(data):
             errors.append('Hours worked cannot exceed 24')
     except (ValueError, TypeError):
         errors.append('Hours worked must be a valid number')
-    
+
+    # Comments (optional)
+    comments = data.get('comments', '')
+    if comments is not None:
+        comments = str(comments).strip()
+        if len(comments) > 500:
+            errors.append('Comments cannot exceed 500 characters')
+
     return errors, {
         'cash_tips': round(cash_tips, 2),
         'card_tips': round(card_tips, 2),
-        'hours_worked': round(hours_worked, 2)
+        'hours_worked': round(hours_worked, 2),
+        'comments': comments
     }
 
 @api_bp.route('/tips', methods=['POST'])
@@ -87,7 +95,8 @@ def create_tip_entry():
             card_tips=Decimal(str(validated_data['card_tips'])),
             hours_worked=Decimal(str(validated_data['hours_worked'])),
             work_date=work_date,
-            weekday=weekday
+            weekday=weekday,
+            comments=validated_data.get('comments') or None
         )
         
         db.session.add(tip_entry)

--- a/demo_data.py
+++ b/demo_data.py
@@ -14,7 +14,7 @@ def get_demo_data(data_type):
             hours_worked = round(random.uniform(4, 10), 2)
             total_tips = cash_tips + card_tips
             tips_per_hour = round(total_tips / hours_worked, 2)
-            
+
             demo_tips.append({
                 'id': i + 1,
                 'user_id': 'demo-user',
@@ -25,6 +25,7 @@ def get_demo_data(data_type):
                 'weekday': work_date.weekday(),
                 'total_tips': total_tips,
                 'tips_per_hour': tips_per_hour,
+                'comments': random.choice(['Busy night', 'Slow shift', 'Great tips', '']),
                 'created_at': f"{work_date}T18:00:00Z",
                 'updated_at': f"{work_date}T18:00:00Z"
             })

--- a/models.py
+++ b/models.py
@@ -28,6 +28,7 @@ class TipEntry(db.Model):
     weekday = db.Column(db.Integer, nullable=False)  # 0=Monday, 6=Sunday
     total_tips = db.Column(db.Numeric(10, 2), nullable=False)  # Computed field
     tips_per_hour = db.Column(db.Numeric(8, 2), nullable=False)  # Computed field
+    comments = db.Column(db.Text, nullable=True)
     created_at = db.Column(db.DateTime(timezone=True), default=func.now())
     updated_at = db.Column(db.DateTime(timezone=True), default=func.now(), onupdate=func.now())
     
@@ -51,6 +52,7 @@ class TipEntry(db.Model):
             'weekday': self.weekday,
             'total_tips': float(self.total_tips),
             'tips_per_hour': float(self.tips_per_hour),
+            'comments': self.comments,
             'created_at': self.created_at.isoformat(),
             'updated_at': self.updated_at.isoformat()
         }

--- a/schema.sql
+++ b/schema.sql
@@ -34,6 +34,7 @@ create table if not exists public.tip_entries (
   weekday smallint not null check (weekday between 0 and 6), -- 0=Mon .. 6=Sun
   total_tips numeric(10,2) not null default 0,
   tips_per_hour numeric(8,2) not null default 0,
+  comments text,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -3,6 +3,12 @@ let currentUser = null;
 let charts = {};
 let demoMode = false;
 
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
 // Initialize app
 document.addEventListener('DOMContentLoaded', function() {
     checkAuthStatus();
@@ -151,7 +157,8 @@ async function handleTipSubmission(e) {
     const formData = {
         cash_tips: parseFloat(document.getElementById('cashTips').value) || 0,
         card_tips: parseFloat(document.getElementById('cardTips').value) || 0,
-        hours_worked: parseFloat(document.getElementById('hoursWorked').value) || 0
+        hours_worked: parseFloat(document.getElementById('hoursWorked').value) || 0,
+        comments: document.getElementById('comments').value.trim()
     };
     
     const submitBtn = document.getElementById('submitTipBtn');
@@ -294,7 +301,7 @@ async function loadTipEntries() {
             const tips = data.tips || [];
 
             if (!tips.length) {
-                tbody.innerHTML = '<tr><td colspan="7" class="text-center text-muted">No entries found</td></tr>';
+                tbody.innerHTML = '<tr><td colspan="8" class="text-center text-muted">No entries found</td></tr>';
                 return;
             }
 
@@ -306,16 +313,17 @@ async function loadTipEntries() {
                     <td>$${tip.total_tips.toFixed(2)}</td>
                     <td>${tip.hours_worked.toFixed(2)}</td>
                     <td>$${tip.tips_per_hour.toFixed(2)}</td>
+                    <td>${tip.comments ? escapeHtml(tip.comments) : ''}</td>
                     <td><button class="btn btn-sm btn-outline-danger" onclick="deleteTip(${tip.id})"><i class="fas fa-trash"></i></button></td>
                 </tr>
             `).join('');
         } else {
-            tbody.innerHTML = '<tr><td colspan="7" class="text-center text-danger">Failed to load entries</td></tr>';
+            tbody.innerHTML = '<tr><td colspan="8" class="text-center text-danger">Failed to load entries</td></tr>';
         }
     } catch (error) {
         console.error('Failed to load tips:', error);
         const tbody = document.getElementById('tipsTableBody');
-        tbody.innerHTML = '<tr><td colspan="7" class="text-center text-danger">Failed to load entries</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="8" class="text-center text-danger">Failed to load entries</td></tr>';
     }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -104,8 +104,12 @@
                                 </div>
                                 <div class="mb-3">
                                     <label for="hoursWorked" class="form-label">Hours Worked</label>
-                                    <input type="number" class="form-control" id="hoursWorked" 
+                                    <input type="number" class="form-control" id="hoursWorked"
                                            step="0.25" min="0.25" max="24" placeholder="8.0">
+                                </div>
+                                <div class="mb-3">
+                                    <label for="comments" class="form-label">Comments</label>
+                                    <textarea class="form-control" id="comments" rows="2" placeholder="Optional notes about your shift"></textarea>
                                 </div>
                                 <button type="submit" class="btn btn-primary w-100" id="submitTipBtn">
                                     <i class="fas fa-save me-2"></i>
@@ -193,12 +197,13 @@
                                             <th>Total</th>
                                             <th>Hours</th>
                                             <th>Tips/Hour</th>
+                                            <th>Comments</th>
                                             <th></th>
                                         </tr>
                                     </thead>
                                     <tbody id="tipsTableBody">
                                         <tr>
-                                            <td colspan="7" class="text-center text-muted">Loading...</td>
+                                            <td colspan="8" class="text-center text-muted">Loading...</td>
                                         </tr>
                                     </tbody>
                                 </table>


### PR DESCRIPTION
## Summary
- allow optional comments on tip entries
- display comments in Tip History
- extend schema and demo data to include comments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898f503639c8324a5224b6bf523bea5