### PR TITLE
Show entry owner in tip history for managers

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -192,6 +192,7 @@
                                     <thead>
                                         <tr>
                                             <th>Date</th>
+                                            <th id="userColumnHeader" class="d-none">User</th>
                                             <th>Cash</th>
                                             <th>Card</th>
                                             <th>Total</th>


### PR DESCRIPTION
## Summary
- Add user column to Tip History table and display only for managers
- Provide user name with each tip entry from API
- Toggle column and adjust table output based on authenticated role

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898fc60a4648324b9d13c72920b3f7a