### PR TITLE
Add date picker to tip entry form

### DIFF
--- a/api.py
+++ b/api.py
@@ -50,11 +50,25 @@ def validate_tip_entry(data):
         if len(comments) > 500:
             errors.append('Comments cannot exceed 500 characters')
 
+    # Validate work_date
+    work_date_str = data.get('work_date')
+    if work_date_str:
+        try:
+            work_date = date.fromisoformat(work_date_str)
+            if work_date > date.today():
+                errors.append('Work date cannot be in the future')
+        except ValueError:
+            errors.append('Invalid date format. Use YYYY-MM-DD')
+            work_date = date.today()
+    else:
+        work_date = date.today()
+
     return errors, {
         'cash_tips': round(cash_tips, 2),
         'card_tips': round(card_tips, 2),
         'hours_worked': round(hours_worked, 2),
-        'comments': comments
+        'comments': comments,
+        'work_date': work_date
     }
 
 @api_bp.route('/tips', methods=['POST'])
@@ -85,8 +99,8 @@ def create_tip_entry():
             db.session.add(user)
             db.session.commit()
         
-        # Get work date (server-side)
-        work_date = date.today()
+        # Get work date from input (defaults to today)
+        work_date = validated_data['work_date']
         weekday = work_date.weekday()  # 0=Monday, 6=Sunday
         
         # Create tip entry

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -227,6 +227,12 @@ async function loadUserRole() {
 function setupEventListeners() {
     // Tip form submission
     document.getElementById('tipForm').addEventListener('submit', handleTipSubmission);
+
+    // Set default tip date to today
+    const tipDateInput = document.getElementById('tipDate');
+    if (tipDateInput) {
+        tipDateInput.value = new Date().toISOString().split('T')[0];
+    }
     
     // Demo mode toggle
     document.getElementById('demoModeToggle').addEventListener('change', function(e) {
@@ -258,7 +264,8 @@ async function handleTipSubmission(e) {
         cash_tips: parseFloat(document.getElementById('cashTips').value) || 0,
         card_tips: parseFloat(document.getElementById('cardTips').value) || 0,
         hours_worked: parseFloat(document.getElementById('hoursWorked').value) || 0,
-        comments: document.getElementById('comments').value.trim()
+        comments: document.getElementById('comments').value.trim(),
+        work_date: document.getElementById('tipDate').value || new Date().toISOString().split('T')[0]
     };
     
     const submitBtn = document.getElementById('submitTipBtn');
@@ -281,6 +288,10 @@ async function handleTipSubmission(e) {
         if (response.ok) {
             showAlert('Tip entry saved successfully!', 'success');
             document.getElementById('tipForm').reset();
+            const tipDateInput = document.getElementById('tipDate');
+            if (tipDateInput) {
+                tipDateInput.value = new Date().toISOString().split('T')[0];
+            }
             loadDashboard();
         } else {
             if (result.errors) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -135,10 +135,14 @@
                         </div>
                         <div class="card-body">
                             <form id="tipForm">
+                                <div class="mb-3">
+                                    <label for="tipDate" class="form-label">Date</label>
+                                    <input type="date" class="form-control" id="tipDate">
+                                </div>
                                 <div class="row">
                                     <div class="col-md-6 mb-3">
                                         <label for="cashTips" class="form-label">Cash Tips ($)</label>
-                                        <input type="number" class="form-control" id="cashTips" 
+                                        <input type="number" class="form-control" id="cashTips"
                                                step="0.01" min="0" placeholder="0.00">
                                     </div>
                                     <div class="col-md-6 mb-3">


### PR DESCRIPTION
## Summary
- allow choosing tip date when adding entries
- default tip date to today and reset after save
- validate optional work_date on server

## Testing
- `python -m py_compile api.py`
- `node --check static/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68990ab71ba08324a4e24d28ea411020