### PR TITLE
Fix Quick Stats layout on mobile

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -114,12 +114,9 @@ body {
         gap: 0.5rem;
     }
     
-    #quickStats .row {
+    #quickStats .row,
+    #publicQuickStats .row {
         text-align: center;
-    }
-    
-    #quickStats .col-4 {
-        margin-bottom: 1rem;
     }
 }
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -129,30 +129,30 @@ async function loadDemoQuickStats(elementId) {
             const breakdown = data.breakdown;
             document.getElementById(elementId).innerHTML = `
                 <div class="row">
-                    <div class="col-2">
+                    <div class="col-6 col-md-4 col-lg-2 mb-3 mb-lg-0">
                         <h6 class="text-success">Total Tips</h6>
                         <h4>$${breakdown.total_tips.toFixed(2)}</h4>
                     </div>
-                    <div class="col-2">
+                    <div class="col-6 col-md-4 col-lg-2 mb-3 mb-lg-0">
                         <h6 class="text-info">Cash</h6>
                         <h5>$${breakdown.cash_tips.toFixed(2)}</h5>
                         <small class="text-muted">${breakdown.cash_percentage}%</small>
                     </div>
-                    <div class="col-2">
+                    <div class="col-6 col-md-4 col-lg-2 mb-3 mb-lg-0">
                         <h6 class="text-warning">Card</h6>
                         <h5>$${breakdown.card_tips.toFixed(2)}</h5>
                         <small class="text-muted">${breakdown.card_percentage}%</small>
                     </div>
-                    <div class="col-2">
+                    <div class="col-6 col-md-4 col-lg-2 mb-3 mb-lg-0">
                         <h6 class="text-primary">Tip %</h6>
                         <h5>${breakdown.tip_percentage.toFixed(2)}%</h5>
                         <small class="text-muted">on $${breakdown.total_sales.toFixed(2)}</small>
                     </div>
-                    <div class="col-2">
+                    <div class="col-6 col-md-4 col-lg-2 mb-3 mb-lg-0">
                         <h6 class="text-secondary">Hours</h6>
                         <h5>${breakdown.total_hours.toFixed(2)}</h5>
                     </div>
-                    <div class="col-2">
+                    <div class="col-6 col-md-4 col-lg-2 mb-3 mb-lg-0">
                         <h6 class="text-danger">Avg $/hr</h6>
                         <h5>$${breakdown.avg_tips_per_hour.toFixed(2)}</h5>
                     </div>
@@ -441,30 +441,30 @@ async function loadQuickStats() {
             
             document.getElementById('quickStats').innerHTML = `
                 <div class="row">
-                    <div class="col-2">
+                    <div class="col-6 col-md-4 col-lg-2 mb-3 mb-lg-0">
                         <h6 class="text-success">Total Tips</h6>
                         <h4>$${breakdown.total_tips.toFixed(2)}</h4>
                     </div>
-                    <div class="col-2">
+                    <div class="col-6 col-md-4 col-lg-2 mb-3 mb-lg-0">
                         <h6 class="text-info">Cash</h6>
                         <h5>$${breakdown.cash_tips.toFixed(2)}</h5>
                         <small class="text-muted">${breakdown.cash_percentage}%</small>
                     </div>
-                    <div class="col-2">
+                    <div class="col-6 col-md-4 col-lg-2 mb-3 mb-lg-0">
                         <h6 class="text-warning">Card</h6>
                         <h5>$${breakdown.card_tips.toFixed(2)}</h5>
                         <small class="text-muted">${breakdown.card_percentage}%</small>
                     </div>
-                    <div class="col-2">
+                    <div class="col-6 col-md-4 col-lg-2 mb-3 mb-lg-0">
                         <h6 class="text-primary">Tip %</h6>
                         <h5>${breakdown.tip_percentage.toFixed(2)}%</h5>
                         <small class="text-muted">on $${breakdown.total_sales.toFixed(2)}</small>
                     </div>
-                    <div class="col-2">
+                    <div class="col-6 col-md-4 col-lg-2 mb-3 mb-lg-0">
                         <h6 class="text-secondary">Hours</h6>
                         <h5>${breakdown.total_hours.toFixed(2)}</h5>
                     </div>
-                    <div class="col-2">
+                    <div class="col-6 col-md-4 col-lg-2 mb-3 mb-lg-0">
                         <h6 class="text-danger">Avg $/hr</h6>
                         <h5>$${breakdown.avg_tips_per_hour.toFixed(2)}</h5>
                     </div>


### PR DESCRIPTION
## Summary
- Make Quick Stats grid responsive with Bootstrap classes
- Center Quick Stats content on small screens for public and authenticated views

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c3395c68208324a65e39872aee7b20